### PR TITLE
Refactor flushing

### DIFF
--- a/include/lpf/core.h
+++ b/include/lpf/core.h
@@ -2384,7 +2384,17 @@ lpf_err_t lpf_get_sent_msg_count_per_slot( lpf_t ctx, size_t *sent_msgs, lpf_mem
  * libraries.
  */
 extern _LPFLIB_API
-lpf_err_t lpf_flush( lpf_t ctx);
+lpf_err_t lpf_flush_sent( lpf_t ctx);
+
+/**
+ * This function blocks until all the incoming received messages
+ * waiting on the receive completion queue are handled (via ibv_poll_cq).
+ * No concept of slots is used here.
+ * This allows to reuse the send buffers e.g. in higher-level channel
+ * libraries.
+ */
+extern _LPFLIB_API
+lpf_err_t lpf_flush_received( lpf_t ctx);
 
 #ifdef __cplusplus
 }

--- a/include/lpf/static_dispatch.h
+++ b/include/lpf/static_dispatch.h
@@ -47,7 +47,8 @@
 #undef lpf_get_rcvd_msg_count_per_slot
 #undef lpf_get_sent_msg_count_per_slot
 #undef lpf_register_global
-#undef lpf_flush
+#undef lpf_flush_sent
+#undef lpf_flush_received
 #undef lpf_deregister
 #undef lpf_probe
 #undef lpf_resize_memory_register
@@ -95,7 +96,8 @@
 #define lpf_get_rcvd_msg_count LPF_FUNC(get_rcvd_msg_count)
 #define lpf_get_rcvd_msg_count_per_slot LPF_FUNC(get_rcvd_msg_count_per_slot)
 #define lpf_get_sent_msg_count_per_slot LPF_FUNC(get_sent_msg_count_per_slot)
-#define lpf_flush LPF_FUNC(flush)
+#define lpf_flush_sent LPF_FUNC(flush_sent)
+#define lpf_flush_received LPF_FUNC(flush_received)
 #define lpf_register_global LPF_FUNC(register_global)
 #define lpf_deregister      LPF_FUNC(deregister)
 #define lpf_probe           LPF_FUNC(probe)

--- a/src/MPI/core.cpp
+++ b/src/MPI/core.cpp
@@ -340,11 +340,20 @@ lpf_err_t lpf_get_sent_msg_count_per_slot( lpf_t ctx, size_t * sent_msgs, lpf_me
     return LPF_SUCCESS;
 }
 
-lpf_err_t lpf_flush( lpf_t ctx)
+lpf_err_t lpf_flush_sent( lpf_t ctx)
 {
     lpf::Interface * i = realContext(ctx);
     if (!i->isAborted()) {
-        i->flush();
+        i->flushSent();
+    }
+    return LPF_SUCCESS;
+}
+
+lpf_err_t lpf_flush_received( lpf_t ctx)
+{
+    lpf::Interface * i = realContext(ctx);
+    if (!i->isAborted()) {
+        i->flushReceived();
     }
     return LPF_SUCCESS;
 }

--- a/src/MPI/ibverbs.cpp
+++ b/src/MPI/ibverbs.cpp
@@ -25,7 +25,7 @@
 #include <unistd.h>
 #include <algorithm>
 
-#define POLL_BATCH 8
+#define POLL_BATCH 64
 #define MAX_POLLING 128
 
 
@@ -82,7 +82,7 @@ IBVerbs :: IBVerbs( Communication & comm )
     , m_postCount(0)
     , m_recvCount(0)
     , m_numMsgs(0)
-    , m_sendTotalInitMsgCount(0)
+    //, m_sendTotalInitMsgCount(0)
     , m_recvTotalInitMsgCount(0)
     , m_sentMsgs(0)
     , m_recvdMsgs(0)
@@ -248,7 +248,7 @@ IBVerbs :: ~IBVerbs()
 { }
 
 
-void IBVerbs :: tryIncrement(Op op, Phase phase, SlotID slot) {
+inline void IBVerbs :: tryIncrement(Op op, Phase phase, SlotID slot) {
     
     switch (phase) {
         case Phase::INIT:
@@ -256,27 +256,38 @@ void IBVerbs :: tryIncrement(Op op, Phase phase, SlotID slot) {
             m_recvInitMsgCount[slot] = 0;
             sentMsgCount[slot] = 0;
             m_sendInitMsgCount[slot] = 0;
+            m_getInitMsgCount[slot] = 0;
+            getMsgCount[slot] = 0;
             break;
         case Phase::PRE:
-            m_numMsgs++;
             if (op == Op::SEND) {
-                m_sendTotalInitMsgCount++;
+                m_numMsgs++;
+                //m_sendTotalInitMsgCount++;
                 m_sendInitMsgCount[slot]++;
             }
             if (op == Op::RECV) {
                 m_recvTotalInitMsgCount++;
                 m_recvInitMsgCount[slot]++;
             }
+            if (op == Op::GET) {
+                m_getInitMsgCount[slot]++;
+            }
             break;
         case Phase::POST:
             if (op == Op::RECV) {
+                m_recvdMsgs ++;
                 rcvdMsgCount[slot]++;
             }
             if (op == Op::SEND) {
+                m_sentMsgs++;
                 sentMsgCount[slot]++;
+            }
+            if (op == Op::GET) {
+                getMsgCount[slot]++;
             }
             break;
     }
+    std::cout << "Process " << m_pid << " tryIncrement phase = " << phase << " slot = " << slot << " m_sendInitMsgCount = " << m_sendInitMsgCount[slot] << "sentMsgCount = " << sentMsgCount[slot] << " m_getInitMsgCount = " << m_getInitMsgCount[slot] << " getMsgCount = " << getMsgCount[slot] << std::endl; // " and new m_numMsgs = " << m_numMsgs <<  " m_sentMsgs = " << m_sentMsgs << std::endl;
 }
 
 void IBVerbs :: stageQPs( size_t maxMsgs )
@@ -358,8 +369,8 @@ void IBVerbs :: doRemoteProgress() {
                 SlotID slot = wcs[i].imm_data;
                 // Ignore compare-and-swap atomics!
                 if (wcs[i].opcode != IBV_WC_COMP_SWAP) {
-                    m_recvdMsgs ++;
                     tryIncrement(Op::RECV, Phase::POST, slot);
+                    //std::cout << "Process " << m_pid << " Just recvd a message because of slot " << slot << " and m_recvdMsgs = " << m_recvdMsgs << std::endl;
                     LOG(3, "Rank " << m_pid << " increments received message count to " << rcvdMsgCount[slot] << " for LPF slot " << slot);
                 }
                 ibv_post_srq_recv(m_srq.get(), &wr, &bad_wr);
@@ -724,6 +735,7 @@ blockingCompareAndSwap:
 void IBVerbs :: put( SlotID srcSlot, size_t srcOffset,
               int dstPid, SlotID dstSlot, size_t dstOffset, size_t size)
 {
+    //std::cout << "Process " << m_pid << " put\n";
     const MemorySlot & src = m_memreg.lookup( srcSlot );
     const MemorySlot & dst = m_memreg.lookup( dstSlot );
 
@@ -786,6 +798,7 @@ void IBVerbs :: put( SlotID srcSlot, size_t srcOffset,
 void IBVerbs :: get( int srcPid, SlotID srcSlot, size_t srcOffset,
               SlotID dstSlot, size_t dstOffset, size_t size )
 {
+    //std::cout << "Process " << m_pid << " get\n";
     const MemorySlot & src = m_memreg.lookup( srcSlot );
 	const MemorySlot & dst = m_memreg.lookup( dstSlot );
 
@@ -812,14 +825,18 @@ void IBVerbs :: get( int srcPid, SlotID srcSlot, size_t srcOffset,
 		sge->length = std::min<size_t>(size, m_maxMsgSize );
 		sge->lkey = dst.mr->lkey;
 
-		sr->next = &srs[i+1];
-		sr->send_flags = 0;
+		sr->next = NULL; // &srs[i+1];
+		sr->send_flags = IBV_SEND_SIGNALED; //0;
 
 		sr->sg_list = sge;
 		sr->num_sge = 1;
 		sr->opcode = IBV_WR_RDMA_READ;
 		sr->wr.rdma.remote_addr = reinterpret_cast<uintptr_t>( remoteAddr );
 		sr->wr.rdma.rkey = src.glob[srcPid].rkey;
+        // This logic is reversed compared to ::put
+        // (not srcSlot, as this slot is remote)
+        sr->wr_id = dstSlot;
+        sr->imm_data = dstSlot;
 
 		size -= sge->length;
 		srcOffset += sge->length;
@@ -827,9 +844,10 @@ void IBVerbs :: get( int srcPid, SlotID srcSlot, size_t srcOffset,
 	}
 
 	// add extra "message" to do the local and remote completion
-	sge = &sges[numMsgs]; std::memset(sge, 0, sizeof(ibv_sge));
-	sr = &srs[numMsgs]; std::memset(sr, 0, sizeof(ibv_send_wr));
+	//sge = &sges[numMsgs]; std::memset(sge, 0, sizeof(ibv_sge));
+	//sr = &srs[numMsgs]; std::memset(sr, 0, sizeof(ibv_send_wr));
 
+    /*
 	const char * localAddr = static_cast<const char *>(dst.glob[m_pid].addr);
 	const char * remoteAddr = static_cast<const char *>(src.glob[srcPid].addr);
 
@@ -844,12 +862,14 @@ void IBVerbs :: get( int srcPid, SlotID srcSlot, size_t srcOffset,
 	sr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
 	sr->sg_list = sge;
 	sr->num_sge = 0;
+    // Should srcSlot and dstSlot be reversed for get?
     sr->wr_id = srcSlot;
 	sr->imm_data = dstSlot;
 	sr->wr.rdma.remote_addr = reinterpret_cast<uintptr_t>( remoteAddr );
 	sr->wr.rdma.rkey = src.glob[srcPid].rkey;
 
 	//Send
+    */
 	struct ibv_send_wr *bad_wr = NULL;
 	if (int err = ibv_post_send(m_connectedQps[srcPid].get(), &srs[0], &bad_wr ))
 	{
@@ -860,7 +880,7 @@ void IBVerbs :: get( int srcPid, SlotID srcSlot, size_t srcOffset,
         }
 		throw Exception("Error while posting RDMA requests");
 	}
-    tryIncrement(Op::SEND, Phase::PRE, dstSlot);
+    tryIncrement(Op::GET, Phase::PRE, dstSlot);
 
 }
 
@@ -911,8 +931,13 @@ std::vector<ibv_wc_opcode> IBVerbs :: wait_completion(int& error) {
             opcodes.push_back(wcs[i].opcode);
             // Ignore compare-and-swap atomics!
             if (wcs[i].opcode != IBV_WC_COMP_SWAP) {
-                m_sentMsgs ++;
-                tryIncrement(Op::SEND, Phase::POST, slot);
+                if (wcs[i].opcode == IBV_WC_RDMA_READ)
+                    tryIncrement(Op::GET, Phase::POST, slot);
+                if (wcs[i].opcode == IBV_WC_RDMA_WRITE)
+                    tryIncrement(Op::SEND, Phase::POST, slot);
+
+                //tryIncrement(Op::SEND, Phase::POST, slot);
+                //std::cout << "Process " << m_pid << " Just sent a message because of slot " << slot << " and m_sentMsgs = " << m_sentMsgs << std::endl;
                 LOG(3, "Rank " << m_pid << " increments sent message count to " << sentMsgCount[slot] << " for LPF slot " << slot);
             }
         }
@@ -929,24 +954,33 @@ void IBVerbs :: flush()
 {
     int error = 0;
 
-    while (m_numMsgs > m_sentMsgs) {
-        LOG(1, "Rank " << m_pid << " m_numMsgs = " << m_numMsgs << " m_sentMsgs = " << m_sentMsgs);
-
-        wait_completion(error);
-        if (error) {
-            LOG(1, "Error in wait_completion");
-            std::abort();
+    std::cout << "Process " << m_pid << " begins flush\n";
+    bool sendsComplete;
+    do {
+        sendsComplete = true;
+        for (auto it = m_sendInitMsgCount.begin(); it != m_sendInitMsgCount.end(); it++) {
+            if (it->second > sentMsgCount[it->first]) {
+                sendsComplete = false;
+                wait_completion(error);
+                if (error) {
+                    LOG(1, "Error in wait_completion");
+                    std::abort();
+                }
+            }
         }
+        for (auto it = m_getInitMsgCount.begin(); it != m_getInitMsgCount.end(); it++) {
+            if (it->second > getMsgCount[it->first]) {
+                sendsComplete = false;
+                wait_completion(error);
+                if (error) {
+                    LOG(1, "Error in wait_completion");
+                    std::abort();
+                }
+            }
+        }
+    } while (!sendsComplete);
 
-    }
-    if (m_numMsgs < m_sentMsgs) {
-
-        LOG(1, "Weird, m_numMsgs = " << m_numMsgs << " and m_sentMsgs = " << m_sentMsgs);
-        std::abort();
-    }
-
-    m_numMsgs = 0;
-    m_sentMsgs = 0;
+    std::cout << "Process " << m_pid << " ends flush\n";
 
 }
 
@@ -1009,27 +1043,12 @@ void IBVerbs :: sync(bool resized)
 
     int error = 0;
 
-    while (m_sendTotalInitMsgCount > m_sentMsgs) {
-        LOG(1, "Rank " << m_pid << " m_sendTotalInitMsgCount = " << m_sendTotalInitMsgCount << " m_sentMsgs = " << m_sentMsgs);
+    //std::cout << "Process " << m_pid << "will call reset as part of sync!\n";
+    flush();
 
-        wait_completion(error);
-        if (error) {
-            LOG(1, "Error in wait_completion");
-            std::abort();
-        }
-
-    }
-    if (m_sendTotalInitMsgCount < m_sentMsgs) {
-
-        LOG(1, "Weird, m_sendTotalInitMsgCount = " << m_sendTotalInitMsgCount << " and m_sentMsgs = " << m_sentMsgs);
-        std::abort();
-    }
-
-    m_numMsgs = 0;
-    m_sendTotalInitMsgCount = 0;
-    m_sentMsgs = 0;
     LOG(1, "Process " << m_pid << " will call barrier\n");
     m_comm.barrier();
+
     // at least once in a while the received queues have to be polled for!
     doRemoteProgress();
 

--- a/src/MPI/ibverbs.hpp
+++ b/src/MPI/ibverbs.hpp
@@ -86,7 +86,9 @@ public:
     void get( int srcPid, SlotID srcSlot, size_t srcOffset, 
               SlotID dstSlot, size_t dstOffset, size_t size );
 
-    void flush();
+    void flushSent();
+
+    void flushReceived();
 
     void doRemoteProgress();
 

--- a/src/MPI/ibverbs.hpp
+++ b/src/MPI/ibverbs.hpp
@@ -39,7 +39,8 @@
 
 typedef enum Op {
     SEND,
-    RECV
+    RECV,
+    GET
 } Op;
 
 typedef enum Phase {
@@ -137,11 +138,12 @@ private:
     int          m_pid; // local process ID
     int          m_nprocs; // number of processes
     std::atomic_size_t m_numMsgs;
-    std::atomic_size_t m_sendTotalInitMsgCount;
+    //std::atomic_size_t m_sendTotalInitMsgCount;
     std::atomic_size_t m_recvTotalInitMsgCount;
     std::atomic_size_t m_sentMsgs;
     std::atomic_size_t m_recvdMsgs;
     std::map<SlotID, std::atomic_size_t> m_recvInitMsgCount;
+    std::map<SlotID, std::atomic_size_t> m_getInitMsgCount;
     std::map<SlotID, std::atomic_size_t> m_sendInitMsgCount;
 
     std::string  m_devName; // IB device name
@@ -179,6 +181,7 @@ private:
     shared_ptr<std::thread> progressThread;
     std::map<SlotID, std::atomic_size_t> rcvdMsgCount;
     std::map<SlotID, std::atomic_size_t> sentMsgCount;
+    std::map<SlotID, std::atomic_size_t> getMsgCount;
 
     std::vector< struct ibv_sge > m_sges; // array of scatter/gather entries
     //std::vector< struct ibv_wc > m_wcs; // array of work completions

--- a/src/MPI/interface.cpp
+++ b/src/MPI/interface.cpp
@@ -127,8 +127,12 @@ void Interface :: getSentMsgCountPerSlot(size_t * msgs, SlotID slot) {
     m_mesgQueue.getSentMsgCountPerSlot(msgs, slot);
 }
 
-void Interface :: flush() {
-    m_mesgQueue.flush();
+void Interface :: flushSent() {
+    m_mesgQueue.flushSent();
+}
+
+void Interface :: flushReceived() {
+    m_mesgQueue.flushReceived();
 }
 
 void Interface :: getRcvdMsgCount(size_t * msgs) {

--- a/src/MPI/interface.hpp
+++ b/src/MPI/interface.hpp
@@ -84,7 +84,8 @@ public:
     void getRcvdMsgCountPerSlot(size_t * msgs, SlotID slot);
     void getSentMsgCountPerSlot(size_t * msgs, SlotID slot);
     void getRcvdMsgCount(size_t * msgs);
-    void flush();
+    void flushSent();
+    void flushReceived();
 
     err_t rehook( spmd_t spmd, args_t args);
 

--- a/src/MPI/mesgqueue.cpp
+++ b/src/MPI/mesgqueue.cpp
@@ -391,10 +391,17 @@ void MessageQueue :: getSentMsgCountPerSlot(size_t * msgs, SlotID slot)
 #endif
 }
 
-void MessageQueue :: flush()
+void MessageQueue :: flushSent()
 {
 #ifdef LPF_CORE_MPI_USES_ibverbs
-        m_ibverbs.flush();
+        m_ibverbs.flushSent();
+#endif
+}
+
+void MessageQueue :: flushReceived()
+{
+#ifdef LPF_CORE_MPI_USES_ibverbs
+        m_ibverbs.flushReceived();
 #endif
 }
 

--- a/src/MPI/mesgqueue.hpp
+++ b/src/MPI/mesgqueue.hpp
@@ -73,7 +73,9 @@ public:
 
     void getSentMsgCountPerSlot(size_t * msgs, SlotID slot);
 
-    void flush();
+    void flushSent();
+
+    void flushReceived();
 
     // returns how many processes have entered in an aborted state
     int sync();

--- a/src/hybrid/dispatch.hpp
+++ b/src/hybrid/dispatch.hpp
@@ -121,8 +121,11 @@ namespace lpf { namespace hybrid {
         err_t get_rcvd_msg_count( size_t * rcvd_msgs) 
         { return USE_THREAD( get_rcvd_msg_count)(m_ctx, rcvd_msgs); }
 
-        err_t flush()
-        { return USE_THREAD(flush)(m_ctx); }
+        err_t flush_sent()
+        { return USE_THREAD(flush_sent)(m_ctx); }
+
+        err_t flush_received()
+        { return USE_THREAD(flush_received)(m_ctx); }
 
         err_t put( memslot_t src_slot, size_t src_offset, 
                 pid_t dst_pid, memslot_t dst_slot, size_t dst_offset, 
@@ -229,8 +232,11 @@ namespace lpf { namespace hybrid {
         err_t get_rcvd_msg_count( size_t * rcvd_msgs) 
         { return USE_MPI( get_rcvd_msg_count)(m_ctx, rcvd_msgs); }
 
-        err_t flush()
-        {return USE_MPI( flush)(m_ctx);}
+        err_t flush_sent()
+        {return USE_MPI( flush_sent)(m_ctx);}
+
+        err_t flush_received()
+        {return USE_MPI( flush_received)(m_ctx);}
 
         err_t put( memslot_t src_slot, size_t src_offset, 
                 pid_t dst_pid, memslot_t dst_slot, size_t dst_offset, 

--- a/src/hybrid/state.hpp
+++ b/src/hybrid/state.hpp
@@ -438,7 +438,7 @@ public:
     }
 
     lpf_pid_t flush() {
-        return m_nodeState.mpi().flush();
+        return (m_nodeState.mpi().flush_sent() && m_nodeState.mpi().flush_received());
     }
 
 private:


### PR DESCRIPTION
Separate the flushing, which was previously only for sender queue, into two flush operations:
-lpf_flush_sent
-lpf_flush_received

This is important to have, as some applications separately need to flush send and receive queues, e.g. channels with producers and consumers. It is very important to provide both, as without e.g. lpf_flush_received, it is possible for the application to freeze, being unable to find available slots due to lack of `ibv_post_srq_recv` calls.